### PR TITLE
Fix openjdk jol-core library version

### DIFF
--- a/code/ThreadDemos/pom.xml
+++ b/code/ThreadDemos/pom.xml
@@ -21,7 +21,7 @@
 
         <jmh.version>1.21</jmh.version>
         <jmhJar.name>ThreadDBenchmarks</jmhJar.name>
-        <jol.verson>0.10-SNAPSHOT</jol.verson>
+        <jol.verson>0.10</jol.verson>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Tested out the Maven build in preparation for tomorrow's course. Found I had to remove the -SNAPSHOT from the jol.version to get the dependency to resolve. This might be due to us using on internal Artifactory instance with a selection of mirrored public Maven repos.